### PR TITLE
🐛 Configure SPA fallback on frontend

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -7,3 +7,5 @@ RUN yarn build
 FROM nginx:alpine
 
 COPY --from=builder /src/workadventure/front/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 8080;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html =404;
+    }
+}


### PR DESCRIPTION
Configures a fallback to `index.html` for all routes where a file doesn't exist.
This allows specifying the map to load in the URL when loading the page.

Also changing the listen port for nginx to `8080` so the service can easily run with non-root users.